### PR TITLE
Remove CI environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,7 @@ jobs:
     needs: test
     if: success() && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    environment:
-      name: release
-      url: https://pypi.org/p/careamics-portfolio
+
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
@@ -87,7 +85,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.9"
 
       - name: Build
         run: |


### PR DESCRIPTION
- Remove CI environment

The reason is that a recent Github security update [broke running environments on tags](https://github.com/orgs/community/discussions/62991).